### PR TITLE
Operator controls changes

### DIFF
--- a/boccia-gui/commands.py
+++ b/boccia-gui/commands.py
@@ -34,4 +34,12 @@ class Commands():
         "Drop": "dd-70",
         }
     
+    OPERATOR_COMMANDS = {
+        "A ←": "rs0",
+        "→ D": "rs1",
+        "W ↑": "es1",
+        "S ↓": "es0",
+        "Drop \n(R)": "dd-70",
+    }
+    
     HELP_URL = "https://github.com/kirtonBCIlab/Boccia-T2S-controller/wiki"

--- a/boccia-gui/commands.py
+++ b/boccia-gui/commands.py
@@ -52,6 +52,7 @@ class Commands():
 
         self.user_controls_widget = None
         self.key_press_handler = None
+        self.operator_controls_widget = None
 
         self.toggle_command_active = False
 
@@ -60,6 +61,9 @@ class Commands():
 
     def set_key_press_handler(self, key_press_handler):
         self.key_press_handler = key_press_handler
+
+    def set_operator_controls_widget(self, operator_controls_widget):
+        self.operator_controls_widget = operator_controls_widget
 
     def drop_delay_timer(self):
         
@@ -82,6 +86,7 @@ class Commands():
         self.drop_delay_active = False # Reset the drop delay flag
         self.key_press_handler.reset_flags()
         self.user_controls_widget._reset_buttons_and_flags()
+        self.operator_controls_widget._reset_buttons_and_flag()
 
     def get_drop_delay_active(self):
         return self.drop_delay_active

--- a/boccia-gui/key_press_handler.py
+++ b/boccia-gui/key_press_handler.py
@@ -46,9 +46,21 @@ class KeyPressHandler(QObject):
             
             if (key in Commands.HOLD_COMMANDS):
                 print(f"\nOperator key pressed: {key}")
+
+                # Get the command
                 command = Commands.HOLD_COMMANDS[key]
+
+                # If service is active, return
+                if self.service_flag:
+                    return
+                
+                # Otherwise, send the command
                 self.serial_handler.send_command(command)
                 self.key_pressed = key
+                print(f"Start {command} command")
+
+                self.toggle_service_flag(True)
+                self.key_service_flag_changed.emit(True)
 
             elif key in Commands.TOGGLE_COMMANDS:
                 print(f"\nUser key pressed: {key}")
@@ -98,6 +110,10 @@ class KeyPressHandler(QObject):
                 command = Commands.HOLD_COMMANDS[key]
                 self.serial_handler.send_command(command)
                 self.key_pressed = None
+                print(f"Stop {command} command")
+                
+                self.toggle_service_flag(False)
+                self.key_service_flag_changed.emit(False)
 
             event.accept()
 

--- a/boccia-gui/main_window.py
+++ b/boccia-gui/main_window.py
@@ -82,6 +82,8 @@ class MainWindow(QMainWindow):
     def set_up_event_connections(self):
         self.key_press_handler.key_service_flag_changed.connect(self.user_controls_widget._on_key_toggled)
         self.user_controls_widget.button_service_flag_changed.connect(self.key_press_handler.toggle_service_flag)
+        self.operator_controls_widget.hold_button_service_flag_changed.connect(self.key_press_handler.toggle_service_flag)
+        self.operator_controls_widget.hold_button_service_flag_changed.connect(self.user_controls_widget._on_key_toggled)
 
 
     def closeEvent(self, event):

--- a/boccia-gui/main_window.py
+++ b/boccia-gui/main_window.py
@@ -80,8 +80,15 @@ class MainWindow(QMainWindow):
 
 
     def set_up_event_connections(self):
+        # KeyPressHandler sends service flag
         self.key_press_handler.key_service_flag_changed.connect(self.user_controls_widget._on_key_toggled)
+        self.key_press_handler.key_service_flag_changed.connect(self.operator_controls_widget._receive_service_flag)
+
+        # UserControlsWidget sends service flag  
         self.user_controls_widget.button_service_flag_changed.connect(self.key_press_handler.toggle_service_flag)
+        self.user_controls_widget.button_service_flag_changed.connect(self.operator_controls_widget._receive_service_flag)
+
+         # OperatorControlsWidget sends service flag
         self.operator_controls_widget.hold_button_service_flag_changed.connect(self.key_press_handler.toggle_service_flag)
         self.operator_controls_widget.hold_button_service_flag_changed.connect(self.user_controls_widget._on_key_toggled)
 

--- a/boccia-gui/main_window.py
+++ b/boccia-gui/main_window.py
@@ -65,8 +65,9 @@ class MainWindow(QMainWindow):
         self.serial_controls_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         # Create operator controls
-        self.operator_controls_widget = OperatorControlsWidget(self.serial_handler)
+        self.operator_controls_widget = OperatorControlsWidget(self.serial_handler, self.commands)
         self.operator_controls_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.commands.set_operator_controls_widget(self.operator_controls_widget)
 
         # Create user controls
         self.user_controls_widget = UserControlsWidget(self.serial_handler, self.commands)

--- a/boccia-gui/operator_controls_widget.py
+++ b/boccia-gui/operator_controls_widget.py
@@ -172,6 +172,23 @@ class OperatorControlsWidget(QWidget):
         print("Drop button clicked")
         # To Do: connect it to the drop timer
 
+    
+    def _toggle_all_buttons(self, bool):
+        for button in self.findChildren(QPushButton):
+            button.setEnabled(bool)
+            self._update_button_style(button)
+
+    
+    def _update_button_style(self, button):
+        """ Update the button style based on its enabled state """
+        if button.isEnabled():
+            button_style = f"{Styles.HOVER_BUTTON} width: 50px; height: 50px;"
+            button.setStyleSheet(button_style)
+        else:
+            button_style = f"{Styles.DISABLED_BUTTON} width: 50px; height: 50px;"
+            button.setStyleSheet(button_style)
+
+
     def _change_slider_label(self, slider, label):
         """ Update the slider value label """
         label.setText(f"{slider.value()} %")

--- a/boccia-gui/operator_controls_widget.py
+++ b/boccia-gui/operator_controls_widget.py
@@ -18,7 +18,7 @@ from commands import Commands
 
 class OperatorControlsWidget(QWidget):
     hold_button_service_flag_changed = pyqtSignal(bool)
-    
+
     def __init__(self, serial_handler = None):
         super().__init__()
 
@@ -193,6 +193,10 @@ class OperatorControlsWidget(QWidget):
             button_style = f"{Styles.DISABLED_BUTTON} width: 50px; height: 50px;"
             button.setStyleSheet(button_style)
 
+
+    def _receive_service_flag(self, flag):
+        self.service_flag = flag
+        self._toggle_all_buttons(not flag)
 
     def _change_slider_label(self, slider, label):
         """ Update the slider value label """

--- a/boccia-gui/operator_controls_widget.py
+++ b/boccia-gui/operator_controls_widget.py
@@ -1,5 +1,5 @@
 # Standard libraries
-from PyQt5.QtCore import Qt, QEvent
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QLabel,
     QWidget,
@@ -17,6 +17,8 @@ from styles import Styles
 from commands import Commands
 
 class OperatorControlsWidget(QWidget):
+    hold_button_service_flag_changed = pyqtSignal(bool)
+    
     def __init__(self, serial_handler = None):
         super().__init__()
 
@@ -48,6 +50,8 @@ class OperatorControlsWidget(QWidget):
 
         for button in self.operator_buttons:
             button.installEventFilter(self)
+
+        self.service_flag = False
 
 
     def _create_operator_controls(self):
@@ -151,21 +155,22 @@ class OperatorControlsWidget(QWidget):
 
     def eventFilter(self, obj, event):
         if obj in self.operator_buttons:
-            if event.type() == QEvent.MouseButtonPress:
+            if event.type() == event.MouseButtonPress:
                 self._handle_button_event(obj, True)
                 return True
-            elif event.type() == QEvent.MouseButtonRelease:
+            elif event.type() == event.MouseButtonRelease:
                 self._handle_button_event(obj, False)
                 return True
         
         return super().eventFilter(obj, event)
     
-    def _handle_button_event(self, button, is_press):
+    def _handle_button_event(self, button, button_flag):
         button_text = button.text()
 
         if (button_text in Commands.OPERATOR_COMMANDS):
             command = Commands.OPERATOR_COMMANDS.get(button.text())
-            command_action = "Start" if is_press else "Stop"
+            self.hold_button_service_flag_changed.emit(button_flag)
+            command_action = "Start" if button_flag else "Stop"
             print(f"{command_action} {command} command")
 
     def _handle_drop_click(self):


### PR DESCRIPTION
This will close [Issue 38](https://github.com/kirtonBCIlab/Boccia-T2S-controller/issues/38)

### Description
The Operator Controls buttons on the app should be selectable. Also, similar to the toggle commands, the hold commands for the operator controls buttons and keys (WASD) should not control more than one motor at a time.

### Changes

The buttons in the Operator Controls widget are now selectable by mouse. 

- The Drop button activates the drop delay, same as pressing 3 or selecting the User Controls Drop button.
- The other buttons (rotation left/right and elevation up/down) are the Hold commands. The mouse press sends the command, and then the command is sent again to stop sweeping when the mouse is released.

The Hold commands cannot control more than one motor at a time.

- Both the Operator Controls hold buttons, and the WASD keys use the service_flag system from the PR #35. When a button is being held down, no other buttons or keys can be selected, including the toggle keys. Same for when a WASD key is held down.


### Testing

1. First verify that the Operator Controls buttons can now be selected. 
2. I added print statements to the hold commands to show when the commands are sent. When holding down an Operator Control button (rotation and elevation) using the mouse, pressing any keys (WASD, R, and 1, 2, and 3) should not send any commands. 
3. Similarly, while pressing down one of the hold command keys (WASD), all buttons are disabled and pressing any of the other toggle or hold keys should not send any commands. 
4. Verify that the Operator Control Drop button deactivates all buttons and keys for the 15-second drop delay.