### PR TITLE
Scale up the app size

### DIFF
--- a/boccia-gui/main.py
+++ b/boccia-gui/main.py
@@ -5,7 +5,6 @@ from main_window import MainWindow
 def main():
     app = QApplication(sys.argv)
     mainWindow = MainWindow()
-    mainWindow.resize(1200, 800) # Scaled up by 2x from the previous (600, 400)
     mainWindow.show()
     sys.exit(app.exec_())
 

--- a/boccia-gui/main.py
+++ b/boccia-gui/main.py
@@ -5,7 +5,7 @@ from main_window import MainWindow
 def main():
     app = QApplication(sys.argv)
     mainWindow = MainWindow()
-    mainWindow.resize(600, 400)
+    mainWindow.resize(1200, 800) # Scaled up by 2x from the previous (600, 400)
     mainWindow.show()
     sys.exit(app.exec_())
 

--- a/boccia-gui/main_window.py
+++ b/boccia-gui/main_window.py
@@ -49,6 +49,7 @@ class MainWindow(QMainWindow):
          # Create and set central widget once
         self.centralWidget = QWidget()
         self.setCentralWidget(self.centralWidget)
+        self.centralWidget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
         # Create main layout
         self.mainLayout = QVBoxLayout()

--- a/boccia-gui/main_window.py
+++ b/boccia-gui/main_window.py
@@ -44,6 +44,11 @@ class MainWindow(QMainWindow):
 
         self.set_up_event_connections()
 
+        # Set window size
+        width = 600 * Styles.SCALE_FACTOR
+        height = 400 * Styles.SCALE_FACTOR
+        self.resize(width, height)
+
 
     def init_UI(self):
          # Create and set central widget once

--- a/boccia-gui/operator_controls_widget.py
+++ b/boccia-gui/operator_controls_widget.py
@@ -135,7 +135,7 @@ class OperatorControlsWidget(QWidget):
     def _create_hold_button(self, button_text:str = ""):
         """ Returns the operator buttons for the hold commands """
 
-        button_style = f"{Styles.HOVER_BUTTON} width: 50px; height: 50px;"
+        button_style = f"{Styles.HOVER_BUTTON} width: {50 * Styles.SCALE_FACTOR}px; height: {50 * Styles.SCALE_FACTOR}px;"
         button = QPushButton(button_text)
         button.setStyleSheet(button_style)
         self.operator_buttons.append(button)
@@ -147,7 +147,7 @@ class OperatorControlsWidget(QWidget):
     def _create_drop_button(self, button_text:str = ""):
         """ Returns the drop button for the operator controls """
 
-        button_style = f"{Styles.HOVER_BUTTON} width: 50px; height: 50px;"
+        button_style = f"{Styles.HOVER_BUTTON} width: {50 * Styles.SCALE_FACTOR}px; height: {50 * Styles.SCALE_FACTOR}px;"
         button = QPushButton(button_text)
         button.setStyleSheet(button_style)
         button.clicked.connect(self._handle_drop_click)
@@ -215,10 +215,10 @@ class OperatorControlsWidget(QWidget):
     def _update_button_style(self, button):
         """ Update the button style based on its enabled state """
         if button.isEnabled():
-            button_style = f"{Styles.HOVER_BUTTON} width: 50px; height: 50px;"
+            button_style = f"{Styles.HOVER_BUTTON} width: {50 * Styles.SCALE_FACTOR}px; height: {50 * Styles.SCALE_FACTOR}px;"
             button.setStyleSheet(button_style)
         else:
-            button_style = f"{Styles.DISABLED_BUTTON} width: 50px; height: 50px;"
+            button_style = f"{Styles.DISABLED_BUTTON} width: {50 * Styles.SCALE_FACTOR}px; height: {50 * Styles.SCALE_FACTOR}px;"
             button.setStyleSheet(button_style)
 
 

--- a/boccia-gui/serial_controls_widget.py
+++ b/boccia-gui/serial_controls_widget.py
@@ -84,7 +84,9 @@ class SerialControlsWidget(QWidget):
         self.connect_button = QPushButton('Connect')
         self.connect_button.setStyleSheet(self.connect_button_styles["connect"])
         self.connect_button.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
-        self.connect_button.setContentsMargins(5, 5, 5, 5)  # Add small padding around text
+        self.scaled_margin = int(5 * Styles.SCALE_FACTOR)
+        # Add small padding around text
+        self.connect_button.setContentsMargins(self.scaled_margin, self.scaled_margin, self.scaled_margin, self.scaled_margin)
         self.connect_button.clicked.connect(self._toggle_connection_status)
 
         button_container = QHBoxLayout()
@@ -106,7 +108,7 @@ class SerialControlsWidget(QWidget):
         self.calibration_label.setStyleSheet(Styles.LABEL_TEXT)
 
         self.calibration_combo_box = QComboBox()
-        self.calibration_combo_box.setStyleSheet( f"{Styles.COMBOBOX_BASE} width: 130px;")
+        self.calibration_combo_box.setStyleSheet( f"{Styles.COMBOBOX_BASE} width: {130 * Styles.SCALE_FACTOR}px;")
         self.calibration_combo_box.addItems(Commands.CALIBRATION_COMMANDS.keys())
 
         self.calibration_section = QHBoxLayout()
@@ -118,7 +120,7 @@ class SerialControlsWidget(QWidget):
         self.port_label.setStyleSheet(Styles.LABEL_TEXT)
 
         self.port_combo_box = CustomComboBox()
-        self.port_combo_box.setStyleSheet( f"{Styles.COMBOBOX_BASE} width: 70px;")
+        self.port_combo_box.setStyleSheet( f"{Styles.COMBOBOX_BASE} width: {70 * Styles.SCALE_FACTOR}px;")
         self._populate_ports()
 
 

--- a/boccia-gui/styles.py
+++ b/boccia-gui/styles.py
@@ -2,33 +2,36 @@ class Styles:
     # Backgrounds
     WINDOW_BACKGROUND = "background-color: #2d2d2d; color: #ffffff;"
 
+    # Scaling factor for app sizing
+    SCALE_FACTOR = 2 # USE AN INT VALUE
+
     # Labels
-    MAIN_LABEL = "QLabel { font: 20px Calibri; color: #b48ead; font-weight: bold;}"
-    SUB_LABEL = "QLabel { font: 20px Calibri; color: #b48ead;}"
-    VALUE_TEXT = "font-size: 16px; color: #ffffff;"
-    LABEL_TEXT = "font-size: 16px; color: #a9a9a9;"
+    MAIN_LABEL = f"QLabel {{ font: {20 * SCALE_FACTOR}px Calibri; color: #b48ead; font-weight: bold;}}"
+    SUB_LABEL = f"QLabel {{ font: {20 * SCALE_FACTOR}px Calibri; color: #b48ead;}}"
+    VALUE_TEXT = f"font-size: {16 * SCALE_FACTOR}px; color: #ffffff;"
+    LABEL_TEXT = f"font-size: {16 * SCALE_FACTOR}px; color: #a9a9a9;"
 
     # Buttons
-    BUTTON_BASE = """
-        QPushButton {
-            font-size: 16px;
+    BUTTON_BASE = f"""
+        QPushButton {{
+            font-size: {16 * SCALE_FACTOR}px;
             color: #ffffff;
-            padding: 5px;
-            border-radius: 5px;
-            border: 1px solid #ffffff;
-            }
-        """
+            padding: {5 * SCALE_FACTOR}px;
+            border-radius: {5 * SCALE_FACTOR}px;
+            border: {1 * SCALE_FACTOR}px solid #ffffff;
+        }}
+    """
     
-    DISABLED_BUTTON = """
-        QPushButton {
-            font-size: 16px;
+    DISABLED_BUTTON = f"""
+        QPushButton {{
+            font-size: {16 * SCALE_FACTOR}px;
             color: #a9a9a9;
-            padding: 5px;
-            border-radius: 5px;
-            border: 1px solid #a9a9a9;
+            padding: {5 * SCALE_FACTOR}px;
+            border-radius: {5 * SCALE_FACTOR}px;
+            border: {1 * SCALE_FACTOR}px solid #a9a9a9;
             background-color: #3c3c3c;
-            }
-        """
+        }}
+    """
 
     HOVER_BUTTON = f"""
         {BUTTON_BASE}
@@ -36,28 +39,29 @@ class Styles:
         """
 
     # Combobox
-    COMBOBOX_BASE = """
-        font-size: 16px; 
-        width: 130px; 
+    COMBOBOX_BASE = f"""
+        font-size: {16 * SCALE_FACTOR}px; 
+        width: {130 * SCALE_FACTOR}px; 
         background-color: #3c3c3c; 
         color: #ffffff; 
-        border-radius: 5px; 
-        border: 1px solid #ffffff; 
-        padding: 3px;
+        border-radius: {5 * SCALE_FACTOR}px; 
+        border: {1 * SCALE_FACTOR}px solid #ffffff; 
+        padding: {3 * SCALE_FACTOR}px;
         """
     
     # Slider
-    SLIDER = """
-        QSlider::groove:horizontal {
+    SLIDER = f"""
+        QSlider::groove:horizontal {{
             background: #3c3c3c;
-            height: 10px;
-            }
-        QSlider::handle:horizontal {
+            height: {10 * SCALE_FACTOR}px;  
+        }}
+        QSlider::handle:horizontal {{
             background: #b48ead;
-            width: 20px;
-            margin: -5px 0;
-            }
-        """
+            width: {20 * SCALE_FACTOR}px;  
+            margin: {-5 * SCALE_FACTOR}px 0;
+        }}
+"""
+
     
     @staticmethod
     def create_button_style(brackground_color:str):


### PR DESCRIPTION
This is for [Issue 43](https://github.com/kirtonBCIlab/Boccia-T2S-controller/issues/43) to scale up the app to be more readable on a Surface Pro.

**Changes**
I added a `SCALE_FACTOR` variable to Styles to adjust the size of all the different elements. Note: It seems to work best if the scale factor is an `int` value, so I set it to 2 for now.

Here is what the app size looks like on a Surface Pro:
![image](https://github.com/user-attachments/assets/2f4e342a-9f73-4336-aae4-d058fc7aec0a)
