### PR TITLE
44 change operator buttons to toggle

### DIFF
--- a/boccia-gui/commands.py
+++ b/boccia-gui/commands.py
@@ -79,10 +79,10 @@ class Commands():
         self.timer.setSingleShot(True)
         self.timer.timeout.connect(lambda: self.timer_over())
         self.timer.start(self.drop_delay)
-        print("Drop delay timer started")
+        #print("Drop delay timer started")
 
     def timer_over(self):
-        print("\nDrop delay over")
+        #print("\nDrop delay over")
         self.drop_delay_active = False # Reset the drop delay flag
         self.key_press_handler.reset_flags()
         self.user_controls_widget._reset_buttons_and_flags()

--- a/boccia-gui/key_press_handler.py
+++ b/boccia-gui/key_press_handler.py
@@ -45,7 +45,7 @@ class KeyPressHandler(QObject):
             key = event.key()
             
             if (key in Commands.HOLD_COMMANDS):
-                print(f"\nOperator key pressed: {key}")
+                #print(f"\nOperator key pressed: {key}")
 
                 # Get the command
                 command = Commands.HOLD_COMMANDS[key]
@@ -57,13 +57,13 @@ class KeyPressHandler(QObject):
                 # Otherwise, send the command
                 self.serial_handler.send_command(command)
                 self.key_pressed = key
-                print(f"Start {command} command")
+                #print(f"Start {command} command")
 
                 self.toggle_service_flag(True)
                 self.key_service_flag_changed.emit(True)
 
             elif key in Commands.TOGGLE_COMMANDS:
-                print(f"\nUser key pressed: {key}")
+                #print(f"\nUser key pressed: {key}")
 
                 # Get the command
                 command = Commands.TOGGLE_COMMANDS[key]
@@ -77,7 +77,7 @@ class KeyPressHandler(QObject):
                     
                     # Otherwise, send the command
                     self.serial_handler.send_command(command)
-                    print(f"Stop {command} command")
+                    #print(f"Stop {command} command")
 
                     # Toggle the flag and set the current action
                     self.toggle_service_flag(False)
@@ -88,7 +88,7 @@ class KeyPressHandler(QObject):
                 elif not self.service_flag:
                     # Send the command
                     self.serial_handler.send_command(command)
-                    print(f"Start {command} command")
+                    #print(f"Start {command} command")
 
                     # If Drop key was pressed, start the drop delay timer
                     if command == "dd-70":
@@ -106,11 +106,11 @@ class KeyPressHandler(QObject):
         if not event.isAutoRepeat():
             key = event.key()
             if (key in Commands.HOLD_COMMANDS) and (key == self.key_pressed):
-                print(f"Operator key released: {key}")
+                #print(f"Operator key released: {key}")
                 command = Commands.HOLD_COMMANDS[key]
                 self.serial_handler.send_command(command)
                 self.key_pressed = None
-                print(f"Stop {command} command")
+                #print(f"Stop {command} command")
                 
                 self.toggle_service_flag(False)
                 self.key_service_flag_changed.emit(False)

--- a/boccia-gui/main_window.py
+++ b/boccia-gui/main_window.py
@@ -44,17 +44,11 @@ class MainWindow(QMainWindow):
 
         self.set_up_event_connections()
 
-        # Set window size
-        width = 600 * Styles.SCALE_FACTOR
-        height = 400 * Styles.SCALE_FACTOR
-        self.resize(width, height)
-
 
     def init_UI(self):
          # Create and set central widget once
         self.centralWidget = QWidget()
         self.setCentralWidget(self.centralWidget)
-        self.centralWidget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
         # Create main layout
         self.mainLayout = QVBoxLayout()
@@ -88,7 +82,7 @@ class MainWindow(QMainWindow):
 
     def set_up_event_connections(self):
         # KeyPressHandler sends service flag
-        self.key_press_handler.key_service_flag_changed.connect(self.user_controls_widget._on_key_toggled)
+        self.key_press_handler.key_service_flag_changed.connect(self.user_controls_widget._receive_service_flag)
         self.key_press_handler.key_service_flag_changed.connect(self.operator_controls_widget._receive_service_flag)
 
         # UserControlsWidget sends service flag  
@@ -97,7 +91,7 @@ class MainWindow(QMainWindow):
 
          # OperatorControlsWidget sends service flag
         self.operator_controls_widget.hold_button_service_flag_changed.connect(self.key_press_handler.toggle_service_flag)
-        self.operator_controls_widget.hold_button_service_flag_changed.connect(self.user_controls_widget._on_key_toggled)
+        self.operator_controls_widget.hold_button_service_flag_changed.connect(self.user_controls_widget._receive_service_flag)
 
 
     def closeEvent(self, event):

--- a/boccia-gui/main_window.py
+++ b/boccia-gui/main_window.py
@@ -44,11 +44,17 @@ class MainWindow(QMainWindow):
 
         self.set_up_event_connections()
 
+        # Set window size
+        width = 600 * Styles.SCALE_FACTOR
+        height = 400 * Styles.SCALE_FACTOR
+        self.resize(width, height)
+
 
     def init_UI(self):
          # Create and set central widget once
         self.centralWidget = QWidget()
         self.setCentralWidget(self.centralWidget)
+        self.centralWidget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
         # Create main layout
         self.mainLayout = QVBoxLayout()

--- a/boccia-gui/operator_controls_widget.py
+++ b/boccia-gui/operator_controls_widget.py
@@ -153,25 +153,7 @@ class OperatorControlsWidget(QWidget):
         button.clicked.connect(self._handle_drop_click)
 
         return button
-
-    # def eventFilter(self, obj, event):
-    #     if obj in self.operator_buttons:
-    #         # Block mouse events if buttons are disabled
-    #         if not obj.isEnabled():
-    #             if event.type() in {event.MouseButtonPress, event.MouseButtonRelease}:
-    #                 return True # Block mouse events if buttons are disabled
-    #             return False
-            
-    #         if (event.type() == event.MouseButtonPress):
-    #             # print(f"Operator button pressed: {obj.text()}")
-    #             self._handle_button_clicked(obj, True)
-    #             return True
-    #         elif (event.type() == event.MouseButtonRelease):
-    #             # print(f"Operator button released: {obj.text()}")
-    #             self._handle_button_clicked(obj, False)
-    #             return True
-        
-    #     return super().eventFilter(obj, event)
+    
     
     def _handle_button_clicked(self):
         """ Handle the operator button click """
@@ -215,11 +197,12 @@ class OperatorControlsWidget(QWidget):
             button.setEnabled(is_enable)
             self._update_button_style(button)
 
+
     def _reset_buttons_and_flag(self):
         self._toggle_all_buttons(True)
         self._update_service_flag(False)
 
-    
+
     def _update_button_style(self, button):
         """ Update the button style based on its enabled state """
         if button.isEnabled():
@@ -235,10 +218,11 @@ class OperatorControlsWidget(QWidget):
         self._toggle_all_buttons(not flag)
 
     
-    def _update_service_flag(self, flag):
+    def _update_service_flag(self, flag: bool):
         self.service_flag = flag
         self.hold_button_service_flag_changed.emit(self.service_flag)
         # print(f"Operator controls service flag: {self.service_flag}")
+
 
     def _change_slider_label(self, slider, label):
         """ Update the slider value label """

--- a/boccia-gui/operator_controls_widget.py
+++ b/boccia-gui/operator_controls_widget.py
@@ -154,7 +154,7 @@ class OperatorControlsWidget(QWidget):
 
         return button
     
-    
+
     def _handle_button_clicked(self):
         """ Handle the operator button click """
         sender = self.sender()
@@ -198,11 +198,6 @@ class OperatorControlsWidget(QWidget):
             self._update_button_style(button)
 
 
-    def _reset_buttons_and_flag(self):
-        self._toggle_all_buttons(True)
-        self._update_service_flag(False)
-
-
     def _update_button_style(self, button):
         """ Update the button style based on its enabled state """
         if button.isEnabled():
@@ -213,9 +208,15 @@ class OperatorControlsWidget(QWidget):
             button.setStyleSheet(button_style)
 
 
-    def _receive_service_flag(self, flag):
-        self.service_flag = flag
-        self._toggle_all_buttons(not flag)
+    def _receive_service_flag(self, flag: bool):
+        self.service_flag = flag # toggle the service flag
+        self._toggle_all_buttons(not flag) # toggle the buttons
+        # print(f"Operator controls service flag: {self.service_flag}")
+
+
+    def _reset_buttons_and_flag(self):
+        self._toggle_all_buttons(True)
+        self._update_service_flag(False)
 
     
     def _update_service_flag(self, flag: bool):

--- a/boccia-gui/operator_controls_widget.py
+++ b/boccia-gui/operator_controls_widget.py
@@ -169,7 +169,7 @@ class OperatorControlsWidget(QWidget):
         self._update_service_flag(not self.service_flag)
 
         command_action = "Start" if self.service_flag else "Stop"
-        print(f"{command_action} {command} command")
+        #print(f"{command_action} {command} command")
 
         for button in self.findChildren(QPushButton):
             if button != sender:

--- a/boccia-gui/serial_handler.py
+++ b/boccia-gui/serial_handler.py
@@ -93,10 +93,10 @@ class SerialHandler(QThread):
             try:
                 code_str = command + "\n"
                 self._serial.write(code_str.encode("UTF-8"))
-                print(f"Sent serial: {code_str}")
+                #print(f"Sent serial: {code_str}")
                 self.command_sent = True
             except Exception as e:
-                print(f"Error sending data to serial: {str(e)}")
+                #print(f"Error sending data to serial: {str(e)}")
                 self.command_sent = False
 
     
@@ -127,7 +127,7 @@ class SerialHandler(QThread):
 
     def stop(self):
         """ Stop the thread to read from the serial port """
-        print("serial stopped")
+        #print("serial stopped")
         self._running = False
 
 

--- a/boccia-gui/serial_read_window.py
+++ b/boccia-gui/serial_read_window.py
@@ -39,7 +39,7 @@ class SerialReadWindow(QDialog):
 
 
     def update_output(self, data):
-        print(data)  # Print to terminal
+        #print(data)  # Print to terminal
         self.output_label.setText(self.output_label.text() + data + '\n')
 
 

--- a/boccia-gui/user_controls_widget.py
+++ b/boccia-gui/user_controls_widget.py
@@ -92,7 +92,7 @@ class UserControlsWidget(QWidget):
             self._update_service_flag(not self.service_flag)
 
             command_action = "Start" if self.service_flag else "Stop"
-            print(f"{command_action} {command} command")
+            #print(f"{command_action} {command} command")
             
             for button in self.findChildren(QPushButton):
                 if button != sender:

--- a/boccia-gui/user_controls_widget.py
+++ b/boccia-gui/user_controls_widget.py
@@ -73,25 +73,26 @@ class UserControlsWidget(QWidget):
         """ Handle the command button click """
         sender = self.sender()
         command = Commands.BUTTON_COMMANDS.get(sender.text())
-        print(f"\nUser button clicked: {sender.text()}")
+        # print(f"\nUser button clicked: {sender.text()}")
 
         # If the command is in the list, send it
         if command:
             self.serial_handler.send_command(command)
-            print(f"Sent command: {command}")
 
         # If the command is "Drop", disable all buttons
         if sender.text() == "Drop":
-            self.service_flag = True # Set the service flag
-            self._send_service_flag(self.service_flag)
+            # Update service flag
+            self._update_service_flag(True)
 
             self.commands.drop_delay_timer() # Start the drop delay timer
             self._toggle_all_buttons(False)
 
         # If elevation or rotation, toggle the service flag and the other buttons
         else:
-            self.service_flag = not self.service_flag # toggle the service flag
-            self._send_service_flag(self.service_flag)
+            self._update_service_flag(not self.service_flag)
+
+            command_action = "Start" if self.service_flag else "Stop"
+            print(f"{command_action} {command} command")
             
             for button in self.findChildren(QPushButton):
                 if button != sender:
@@ -111,7 +112,7 @@ class UserControlsWidget(QWidget):
             button.setEnabled(value)
             self._update_button_style(button)
 
-    def _on_key_toggled(self, flag: bool):
+    def _receive_service_flag(self, flag: bool):
         self.service_flag = flag # toggle the service flag
         self._toggle_all_buttons(not flag) # toggle the buttons
         # print(f"User controls service flag: {self.service_flag}")
@@ -120,6 +121,7 @@ class UserControlsWidget(QWidget):
         self._toggle_all_buttons(True) # Re-enable the buttons
         self.service_flag = False # Reset the service flag
 
-    def _send_service_flag(self, flag: bool):
-        # print(f"User controls service flag: {flag}")
+    def _update_service_flag(self, flag: bool):
+        self.service_flag = flag
         self.button_service_flag_changed.emit(flag)
+        # print(f"User controls service flag: {self.service_flag}")


### PR DESCRIPTION
### Description
This will close [Issue 44](https://github.com/kirtonBCIlab/Boccia-T2S-controller/issues/44)

Since the app needs to be operated with the Surface Pro touchscreen, the operator buttons need to be toggle buttons, and not hold commands. The WASD keys are still hold commands.

### Changes

1. The operator buttons now behave the same as the user controls toggle buttons: clicking the button starts that command, and disables all other buttons and all key presses. Clicking the button again stops the command and re-enables all buttons and keys.
2. I also cleaned up the user_controls_widget code a bit to be a little more consistent with operator_controls_widget, since the buttons are handled more similarly now.

### Testing

- Click one of the operator buttons. You should see that only that button remains enabled. All other buttons and all the key commands are disabled until you click that operator button again.
- The WASD keys are still hold commands: the command is active as long as you hold down that key.