### PR TITLE
47 disable speed sliders while ramp is moving

### DIFF
--- a/boccia-gui/operator_controls_widget.py
+++ b/boccia-gui/operator_controls_widget.py
@@ -177,6 +177,8 @@ class OperatorControlsWidget(QWidget):
 
             self._update_button_style(button)
 
+        self._toggle_sliders(not self.service_flag)
+
 
     def _handle_drop_click(self):
         # print("Operator drop button clicked")
@@ -190,12 +192,17 @@ class OperatorControlsWidget(QWidget):
 
         self.commands.drop_delay_timer()
         self._toggle_all_buttons(False)
+        self._toggle_sliders(False)
         
     
     def _toggle_all_buttons(self, is_enable):
         for button in self.findChildren(QPushButton):
             button.setEnabled(is_enable)
             self._update_button_style(button)
+
+    def _toggle_sliders(self, is_enable):
+        for slider in self.findChildren(QSlider):
+            slider.setEnabled(is_enable)
 
 
     def _update_button_style(self, button):
@@ -211,11 +218,13 @@ class OperatorControlsWidget(QWidget):
     def _receive_service_flag(self, flag: bool):
         self.service_flag = flag # toggle the service flag
         self._toggle_all_buttons(not flag) # toggle the buttons
+        self._toggle_sliders(not flag) # toggle the sliders
         # print(f"Operator controls service flag: {self.service_flag}")
 
 
     def _reset_buttons_and_flag(self):
         self._toggle_all_buttons(True)
+        self._toggle_sliders(True)
         self._update_service_flag(False)
 
     

--- a/boccia-gui/operator_controls_widget.py
+++ b/boccia-gui/operator_controls_widget.py
@@ -203,6 +203,7 @@ class OperatorControlsWidget(QWidget):
     def _toggle_sliders(self, is_enable):
         for slider in self.findChildren(QSlider):
             slider.setEnabled(is_enable)
+            self._update_slider_style(slider)
 
 
     def _update_button_style(self, button):
@@ -213,6 +214,14 @@ class OperatorControlsWidget(QWidget):
         else:
             button_style = f"{Styles.DISABLED_BUTTON} width: {50 * Styles.SCALE_FACTOR}px; height: {50 * Styles.SCALE_FACTOR}px;"
             button.setStyleSheet(button_style)
+
+
+    def _update_slider_style(self, slider):
+        """ Update the slider style based on its enabled state """
+        if slider.isEnabled():
+            slider.setStyleSheet(Styles.SLIDER)
+        else:
+            slider.setStyleSheet(Styles.DISABLED_SLIDER)
 
 
     def _receive_service_flag(self, flag: bool):

--- a/boccia-gui/styles.py
+++ b/boccia-gui/styles.py
@@ -60,7 +60,19 @@ class Styles:
             width: {20 * SCALE_FACTOR}px;  
             margin: {-5 * SCALE_FACTOR}px 0;
         }}
-"""
+    """
+
+    DISABLED_SLIDER = f"""
+        QSlider::groove:horizontal {{
+            background: #3c3c3c;
+            height: {10 * SCALE_FACTOR}px;  
+        }}
+        QSlider::handle:horizontal {{
+            background: #a9a9a9;
+            width: {20 * SCALE_FACTOR}px;  
+            margin: {-5 * SCALE_FACTOR}px 0;
+        }}
+    """
 
     
     @staticmethod


### PR DESCRIPTION
This will close [Issue 47](https://github.com/kirtonBCIlab/Boccia-T2S-controller/issues/47)

### Description
The speed adjustment sliders should be disabled while the ramp is in motion.

### Changes
In `operator_controls_widget` added a method to toggle the sliders. This method is called whenever a ramp command is activated/deactivated.

### Testing
Use any keyboard or button command. You should see the slider handle change to its `DISABLED_STYLE`, and you cannot adjust the slider handle with the mouse while the command is active.