### PR TITLE
Add option to customize buttons

### DIFF
--- a/boccia-gui/commands.py
+++ b/boccia-gui/commands.py
@@ -1,5 +1,8 @@
 # Standard libraries
+import json
+import os
 from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtGui import QKeySequence
 
 class Commands():
     CALIBRATION = "calibration"
@@ -14,18 +17,30 @@ class Commands():
         "Elevation - auto": "ec1",
         }
 
-    HOLD_COMMANDS = {
-        Qt.Key_A: "rs0",    # Rotation Left
-        Qt.Key_D: "rs1",    # Rotation Right
-        Qt.Key_W: "es1",    # Elevation Up
-        Qt.Key_S: "es0",    # Elevation Down
+    HOLD_ACTION_COMMANDS = {
+        "rotation_left": "rs0",
+        "rotation_right": "rs1",
+        "elevation_up": "es1",
+        "elevation_down": "es0",
         }
 
-    TOGGLE_COMMANDS = {
-        Qt.Key_1: "es1",    # Elevation up
-        Qt.Key_2: "rs1",    # Rotation right
-        Qt.Key_3: "dd-70",  # Drop - T2S activated
-        Qt.Key_R: "dd-70",  # Drop - Keyboard activated
+    TOGGLE_ACTION_COMMANDS = {
+        "elevation_up": "es1",
+        "rotation_right": "rs1",
+        "drop": "dd-70",
+        }
+
+    DEFAULT_HOLD_KEYS = {
+        "rotation_left": Qt.Key_A,
+        "rotation_right": Qt.Key_D,
+        "elevation_up": Qt.Key_W,
+        "elevation_down": Qt.Key_S,
+        }
+
+    DEFAULT_TOGGLE_KEYS = {
+        "elevation_up": Qt.Key_1,
+        "rotation_right": Qt.Key_2,
+        "drop": Qt.Key_3,
         }
     
     BUTTON_COMMANDS = {
@@ -68,6 +83,9 @@ class Commands():
 
         self.toggle_command_active = False
 
+        self.hold_key_map = dict(self.DEFAULT_HOLD_KEYS)
+        self.toggle_key_map = dict(self.DEFAULT_TOGGLE_KEYS)
+
     def set_user_controls_widget(self, user_controls_widget):
         self.user_controls_widget = user_controls_widget
 
@@ -104,13 +122,95 @@ class Commands():
         return self.drop_delay_active
 
     def get_key_from_hold_command(self, command):
-        for key, value in self.HOLD_COMMANDS.items():
+        for action, value in self.HOLD_ACTION_COMMANDS.items():
             if value == command:
-                # print(f"Key from hold command: {key}")
-                return key
+                return self.hold_key_map.get(action)
             
     def get_key_from_toggle_command(self, command):
-        for key, value in self.TOGGLE_COMMANDS.items():
+        for action, value in self.TOGGLE_ACTION_COMMANDS.items():
             if value == command:
-                # print(f"Key from toggle command: {key}")
-                return key
+                return self.toggle_key_map.get(action)
+
+    def get_hold_command_for_key(self, key):
+        for action, mapped_key in self.hold_key_map.items():
+            if mapped_key == key:
+                return self.HOLD_ACTION_COMMANDS.get(action)
+
+    def get_toggle_command_for_key(self, key):
+        for action, mapped_key in self.toggle_key_map.items():
+            if mapped_key == key:
+                return self.TOGGLE_ACTION_COMMANDS.get(action)
+
+    def get_hold_command_for_action(self, action):
+        return self.HOLD_ACTION_COMMANDS.get(action)
+
+    def get_toggle_command_for_action(self, action):
+        return self.TOGGLE_ACTION_COMMANDS.get(action)
+
+    def get_hold_key_for_action(self, action):
+        return self.hold_key_map.get(action)
+
+    def get_toggle_key_for_action(self, action):
+        return self.toggle_key_map.get(action)
+
+    def get_key_text(self, key):
+        if key is None:
+            return "?"
+        text = QKeySequence(key).toString()
+        return text if text else "?"
+
+    def set_hold_key(self, action, key):
+        self._swap_key(self.hold_key_map, action, key)
+
+    def set_toggle_key(self, action, key):
+        self._swap_key(self.toggle_key_map, action, key)
+
+    def _swap_key(self, key_map, action, new_key):
+        if action not in key_map:
+            return
+
+        current_key = key_map[action]
+        if current_key == new_key:
+            return
+
+        swap_action = None
+        for action_name, mapped_key in key_map.items():
+            if mapped_key == new_key:
+                swap_action = action_name
+                break
+
+        key_map[action] = new_key
+        if swap_action and swap_action != action:
+            key_map[swap_action] = current_key
+
+    def load_key_config(self, file_path):
+        if not os.path.exists(file_path):
+            return False
+
+        try:
+            with open(file_path, "r", encoding="utf-8") as file:
+                data = json.load(file)
+        except (OSError, json.JSONDecodeError):
+            return False
+
+        hold_keys = data.get("hold_keys", {})
+        toggle_keys = data.get("toggle_keys", {})
+
+        for action, key_value in hold_keys.items():
+            if isinstance(key_value, int):
+                self.set_hold_key(action, key_value)
+
+        for action, key_value in toggle_keys.items():
+            if isinstance(key_value, int):
+                self.set_toggle_key(action, key_value)
+
+        return True
+
+    def save_key_config(self, file_path):
+        data = {
+            "hold_keys": self.hold_key_map,
+            "toggle_keys": self.toggle_key_map,
+            }
+
+        with open(file_path, "w", encoding="utf-8") as file:
+            json.dump(data, file, indent=2)

--- a/boccia-gui/key_press_handler.py
+++ b/boccia-gui/key_press_handler.py
@@ -2,7 +2,6 @@
 from PyQt5.QtCore import QObject, Qt, pyqtSignal
 
 # Custom libraries
-from commands import Commands
 
 class KeyPressHandler(QObject):
     key_service_flag_changed = pyqtSignal(bool)
@@ -24,11 +23,14 @@ class KeyPressHandler(QObject):
         self.mapKeys()
 
     def mapKeys(self):
-        for index, key in enumerate(Commands.TOGGLE_COMMANDS.keys()):
+        for index, key in enumerate(self.commands.toggle_key_map.values()):
             self.key_action_map[key] = index + 1
 
     def eventFilter(self, obj, event):
         if event.type() == event.KeyPress:
+            if hasattr(self.parent, "is_remap_mode_active") and self.parent.is_remap_mode_active():
+                if self.parent.handle_remap_key(event):
+                    return True
             if event.key() == Qt.Key_F1:
                 self.parent.serial_controls_widget.open_help_url()
                 return True
@@ -45,15 +47,14 @@ class KeyPressHandler(QObject):
     def keyPressEvent(self, event):
         if not event.isAutoRepeat():
             key = event.key()
-            
-            if (key in Commands.HOLD_COMMANDS):
-                # Get the command
-                command = Commands.HOLD_COMMANDS[key]
-                self.hold_key_pressed(command, key)
 
-            elif (key in Commands.TOGGLE_COMMANDS):
-                # Get the command
-                command = Commands.TOGGLE_COMMANDS[key]
+            command = self.commands.get_hold_command_for_key(key)
+            if command:
+                self.hold_key_pressed(command, key)
+                return
+
+            command = self.commands.get_toggle_command_for_key(key)
+            if command:
                 self.toggle_key_pressed("Player 1", command, key)
                 
             event.accept()
@@ -123,9 +124,9 @@ class KeyPressHandler(QObject):
     def keyReleaseEvent(self, event):
         if not event.isAutoRepeat():
             key = event.key()
-            if (key in Commands.HOLD_COMMANDS) and (key == self.key_pressed):
+            command = self.commands.get_hold_command_for_key(key)
+            if command and (key == self.key_pressed):
                 #print(f"Operator key released: {key}")
-                command = Commands.HOLD_COMMANDS[key]
                 self.serial_handler.send_command(command)
                 self.key_pressed = None
                 #print(f"Stop {command} command")
@@ -171,10 +172,8 @@ class KeyPressHandlerMultiplayer(QObject):
             key = event.key()
 
             # If the key is a toggle command
-            if (key in Commands.TOGGLE_COMMANDS):
-
-                # Get the command:
-                command = Commands.TOGGLE_COMMANDS[key]
+            command = self.commands.get_toggle_command_for_key(key)
+            if command:
                 # Tell the Bluetooth client to send the command
                 self.bluetooth_client_thread.send_command(command)
                 

--- a/boccia-gui/main_window.py
+++ b/boccia-gui/main_window.py
@@ -1,5 +1,7 @@
 # Standard libraries
 import os
+import sys
+from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (
     QWidget,
@@ -29,6 +31,18 @@ class MainWindow(QMainWindow):
 
         # Initialize commands
         self.commands = Commands()
+
+        # Check if app is Python or EXE and set controls config path accordingly
+        if getattr(sys, "frozen", False):
+            base_dir = os.path.dirname(sys.executable)
+        else:
+            base_dir = os.path.dirname(os.path.abspath(__file__))
+
+        self.controls_config_path = os.path.join(base_dir, "controls_config.json")
+        self.commands.load_key_config(self.controls_config_path)
+
+        self.remap_mode_active = False
+        self.remap_target = None
 
         # Set the multiplayer version flag
         # This determines whether or not the window will include the multiplayer functionality
@@ -118,6 +132,11 @@ class MainWindow(QMainWindow):
         self.operator_controls_widget.hold_button_service_flag_changed.connect(self.key_press_handler.toggle_service_flag)
         self.operator_controls_widget.hold_button_service_flag_changed.connect(self.user_controls_widget._receive_service_flag)
 
+        # Remapping controls
+        self.operator_controls_widget.remap_mode_requested.connect(self.toggle_remap_mode)
+        self.operator_controls_widget.remap_target_selected.connect(self.set_remap_target)
+        self.user_controls_widget.remap_target_selected.connect(self.set_remap_target)
+
         # Set up Bluetooth server events if multiplayer controls are included
         if self.include_multiplayer_controls:
             self.bluetooth_server.server_status_changed.connect(self.multiplayer_controls_widget._handle_server_status_change)
@@ -133,3 +152,47 @@ class MainWindow(QMainWindow):
             self.serial_handler.disconnect()
 
         event.accept()
+
+    def toggle_remap_mode(self):
+        self.remap_mode_active = not self.remap_mode_active
+        self.remap_target = None
+        self.operator_controls_widget.set_remap_mode_active(self.remap_mode_active)
+        self.user_controls_widget.set_remap_mode_active(self.remap_mode_active)
+
+    def is_remap_mode_active(self):
+        return self.remap_mode_active
+
+    def set_remap_target(self, group, action):
+        if not self.remap_mode_active:
+            return
+        self.remap_target = (group, action)
+
+    def handle_remap_key(self, event):
+        if not self.remap_mode_active:
+            return False
+
+        if event.isAutoRepeat():
+            return True
+
+        key = event.key()
+        if key == Qt.Key_Escape:
+            self.remap_target = None
+            self.remap_mode_active = False
+            self.operator_controls_widget.set_remap_mode_active(False)
+            self.user_controls_widget.set_remap_mode_active(False)
+            return True
+
+        if not self.remap_target:
+            return True
+
+        group, action = self.remap_target
+        if group == "hold":
+            self.commands.set_hold_key(action, key)
+        elif group == "toggle":
+            self.commands.set_toggle_key(action, key)
+
+        self.commands.save_key_config(self.controls_config_path)
+        self.operator_controls_widget.refresh_key_labels()
+        self.user_controls_widget.refresh_key_labels()
+        self.remap_target = None
+        return True

--- a/boccia-gui/multiplayer_devices_window.py
+++ b/boccia-gui/multiplayer_devices_window.py
@@ -1,5 +1,6 @@
 # Standard libraries
 import os
+import sys
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (
     QWidget,
@@ -26,7 +27,15 @@ class MultiplayerDevicesWindow(QMainWindow):
         super().__init__()
 
         # Initialize instance of the Commands class
+        # - Check if app is Python or EXE and set controls config path accordingly
         self.commands = Commands()
+        if getattr(sys, "frozen", False):
+            base_dir = os.path.dirname(sys.executable)
+        else:
+            base_dir = os.path.dirname(os.path.abspath(__file__))
+
+        self.controls_config_path = os.path.join(base_dir, "controls_config.json")
+        self.commands.load_key_config(self.controls_config_path)
 
         # Initialize instance of the Bluetooth client class
         self.bluetooth_client = BluetoothClient()

--- a/boccia-gui/operator_controls_widget.py
+++ b/boccia-gui/operator_controls_widget.py
@@ -14,10 +14,11 @@ from PyQt5.QtWidgets import (
 
 # Custom libraries
 from styles import Styles
-from commands import Commands
 
 class OperatorControlsWidget(QWidget):
     hold_button_service_flag_changed = pyqtSignal(bool)
+    remap_mode_requested = pyqtSignal()
+    remap_target_selected = pyqtSignal(str, str)
 
     def __init__(self, serial_handler = None, commands = None):
         super().__init__()
@@ -30,7 +31,9 @@ class OperatorControlsWidget(QWidget):
             "rotation": 50
         }
 
-        self.operator_buttons = []
+        self.action_buttons = []
+        self.operator_button_actions = {}
+        self.remap_mode_active = False
         
         # Main label section   
         self.controls_label = QLabel('OPERATOR CONTROLS')
@@ -49,7 +52,7 @@ class OperatorControlsWidget(QWidget):
         self.main_layout.addWidget(self.controls_label)
         self.main_layout.addLayout(self.content_layout)
 
-        for button in self.operator_buttons:
+        for button in self.action_buttons:
             button.installEventFilter(self)
 
         self.service_flag = False
@@ -59,11 +62,11 @@ class OperatorControlsWidget(QWidget):
         """ Initialize UI elements for operator controls"""
 
         # Create buttons
-        up_button = self._create_operator_button('W ↑')
-        down_button = self._create_operator_button('S ↓')
-        left_button = self._create_operator_button('A ←')
-        right_button = self._create_operator_button('→ D')
-        drop_button = self._create_drop_button('Drop \n(R)')
+        up_button = self._create_operator_button(self._format_hold_button_text("elevation_up"), "elevation_up")
+        down_button = self._create_operator_button(self._format_hold_button_text("elevation_down"), "elevation_down")
+        left_button = self._create_operator_button(self._format_hold_button_text("rotation_left"), "rotation_left")
+        right_button = self._create_operator_button(self._format_hold_button_text("rotation_right"), "rotation_right")
+        drop_button = self._create_drop_button(self._format_drop_button_text(), "drop")
         
         # Organize buttons in grid layout
         spacer = QSpacerItem(20, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
@@ -80,8 +83,16 @@ class OperatorControlsWidget(QWidget):
         buttons_layout.setColumnStretch(1, 2)
         buttons_layout.setColumnStretch(2, 2)
 
+        self.config_controls_button = QPushButton("Configure Controls")
+        self.config_controls_button.setStyleSheet(Styles.HOVER_BUTTON)
+        self.config_controls_button.clicked.connect(self._handle_config_button_clicked)
+
+        operator_controls_layout = QVBoxLayout()
+        operator_controls_layout.addLayout(buttons_layout)
+        operator_controls_layout.addWidget(self.config_controls_button)
+
         # Adding the buttons to the layout
-        return buttons_layout
+        return operator_controls_layout
 
 
     def _create_speed_controls(self):
@@ -132,25 +143,28 @@ class OperatorControlsWidget(QWidget):
         return slider_layout
     
 
-    def _create_operator_button(self, button_text:str = ""):
+    def _create_operator_button(self, button_text:str = "", action:str = ""):
         """ Returns the operator buttons for the hold commands """
 
         button_style = f"{Styles.HOVER_BUTTON} width: {50 * Styles.SCALE_FACTOR}px; height: {50 * Styles.SCALE_FACTOR}px;"
         button = QPushButton(button_text)
         button.setStyleSheet(button_style)
         button.clicked.connect(self._handle_button_clicked)
-        self.operator_buttons.append(button)
+        self.action_buttons.append(button)
+        self.operator_button_actions[button] = action
 
         return button
     
 
-    def _create_drop_button(self, button_text:str = ""):
+    def _create_drop_button(self, button_text:str = "", action:str = ""):
         """ Returns the drop button for the operator controls """
 
         button_style = f"{Styles.HOVER_BUTTON} width: {50 * Styles.SCALE_FACTOR}px; height: {50 * Styles.SCALE_FACTOR}px;"
         button = QPushButton(button_text)
         button.setStyleSheet(button_style)
         button.clicked.connect(self._handle_drop_click)
+        self.action_buttons.append(button)
+        self.operator_button_actions[button] = action
 
         return button
     
@@ -158,7 +172,12 @@ class OperatorControlsWidget(QWidget):
     def _handle_button_clicked(self):
         """ Handle the operator button click """
         sender = self.sender()
-        command = Commands.OPERATOR_COMMANDS.get(sender.text())
+        action = self.operator_button_actions.get(sender)
+        if self.remap_mode_active and action:
+            self.remap_target_selected.emit("hold", action)
+            return
+
+        command = self.commands.get_hold_command_for_action(action)
         # print(f"\nOperator button clicked: {sender.text()}")
 
         # If the command is in the list, send it
@@ -171,7 +190,7 @@ class OperatorControlsWidget(QWidget):
         command_action = "Start" if self.service_flag else "Stop"
         #print(f"{command_action} {command} command")
 
-        for button in self.findChildren(QPushButton):
+        for button in self.action_buttons:
             if button != sender:
                 button.setEnabled(not button.isEnabled())
 
@@ -179,9 +198,12 @@ class OperatorControlsWidget(QWidget):
 
 
     def _handle_drop_click(self):
+        if self.remap_mode_active:
+            self.remap_target_selected.emit("toggle", "drop")
+            return
         # print("Operator drop button clicked")
         # Send the command
-        command = Commands.OPERATOR_COMMANDS.get("Drop \n(R)")
+        command = self.commands.get_toggle_command_for_action("drop")
         self.serial_handler.send_command(command)
         # print(f"Sent command: {command}")
 
@@ -193,7 +215,7 @@ class OperatorControlsWidget(QWidget):
         
     
     def _toggle_all_buttons(self, is_enable):
-        for button in self.findChildren(QPushButton):
+        for button in self.action_buttons:
             button.setEnabled(is_enable)
             self._update_button_style(button)
 
@@ -206,6 +228,43 @@ class OperatorControlsWidget(QWidget):
         else:
             button_style = f"{Styles.DISABLED_BUTTON} width: {50 * Styles.SCALE_FACTOR}px; height: {50 * Styles.SCALE_FACTOR}px;"
             button.setStyleSheet(button_style)
+
+
+    def set_remap_mode_active(self, is_active: bool):
+        self.remap_mode_active = is_active
+        if is_active:
+            self.config_controls_button.setText("Configure Controls (On)")
+        else:
+            self.config_controls_button.setText("Configure Controls")
+
+
+    def refresh_key_labels(self):
+        for button, action in self.operator_button_actions.items():
+            if action == "drop":
+                button.setText(self._format_drop_button_text())
+            else:
+                button.setText(self._format_hold_button_text(action))
+
+
+    def _format_hold_button_text(self, action):
+        arrow_map = {
+            "elevation_up": "↑",
+            "elevation_down": "↓",
+            "rotation_left": "←",
+            "rotation_right": "→",
+            }
+        key_text = self.commands.get_key_text(self.commands.get_hold_key_for_action(action))
+        arrow = arrow_map.get(action, "")
+        return f"{key_text} {arrow}".strip()
+
+
+    def _format_drop_button_text(self):
+        key_text = self.commands.get_key_text(self.commands.get_toggle_key_for_action("drop"))
+        return f"Drop \n({key_text})"
+
+
+    def _handle_config_button_clicked(self):
+        self.remap_mode_requested.emit()
 
 
     def _receive_service_flag(self, flag: bool):

--- a/boccia-gui/user_controls_widget.py
+++ b/boccia-gui/user_controls_widget.py
@@ -15,12 +15,18 @@ from commands import Commands
 
 class UserControlsWidget(QWidget):
     button_service_flag_changed = pyqtSignal(bool)
+    remap_target_selected = pyqtSignal(str, str)
 
     def __init__(self, serial_handler = None, commands = None):
         super().__init__()
 
         self.serial_handler = serial_handler
         self.commands = commands
+
+        self.remap_mode_active = False
+        self.command_buttons = []
+        self.command_button_actions = {}
+        self.command_button_labels = {}
 
         # Main label section
         self.controls_label = QLabel('USER CONTROLS')
@@ -41,11 +47,21 @@ class UserControlsWidget(QWidget):
         command_label_layout = QVBoxLayout()
         command_button_layout = QVBoxLayout()
 
-        for [c,command_text] in enumerate(Commands.BUTTON_COMMANDS.keys()):
-            command_label = self._create_command_label(f"Command: {c+1}")
-            command_button = self._create_command_button(command_text)
+        action_map = {
+            "Elevation up": "elevation_up",
+            "Rotation right": "rotation_right",
+            "Drop": "drop",
+            }
+
+        for [c, command_text] in enumerate(Commands.BUTTON_COMMANDS.keys()):
+            action = action_map.get(command_text, "")
+            command_label = self._create_command_label(self._format_command_label(action, c + 1))
+            command_button = self._create_command_button(command_text, action)
             command_label_layout.addWidget(command_label)
             command_button_layout.addWidget(command_button)
+            self.command_buttons.append(command_button)
+            self.command_button_actions[command_button] = action
+            self.command_button_labels[command_button] = command_label
 
         # Organize layout
         self.commands_section_layout = QHBoxLayout()
@@ -60,7 +76,7 @@ class UserControlsWidget(QWidget):
         return label
     
     
-    def _create_command_button(self, button_text:str = ""):
+    def _create_command_button(self, button_text:str = "", action:str = ""):
         """ Create a QPushButton for the command and sets the default style """
         button = QPushButton(button_text)
         button.setStyleSheet(Styles.HOVER_BUTTON)
@@ -74,6 +90,11 @@ class UserControlsWidget(QWidget):
         sender = self.sender()
         command = Commands.BUTTON_COMMANDS.get(sender.text())
         # print(f"\nUser button clicked: {sender.text()}")
+
+        action = self.command_button_actions.get(sender)
+        if self.remap_mode_active and action:
+            self.remap_target_selected.emit("toggle", action)
+            return
 
         # If the command is in the list, send it
         if command:
@@ -94,7 +115,7 @@ class UserControlsWidget(QWidget):
             command_action = "Start" if self.service_flag else "Stop"
             #print(f"{command_action} {command} command")
             
-            for button in self.findChildren(QPushButton):
+            for button in self.command_buttons:
                 if button != sender:
                     button.setEnabled(not button.isEnabled())
 
@@ -108,7 +129,7 @@ class UserControlsWidget(QWidget):
             button.setStyleSheet(Styles.DISABLED_BUTTON)
     
     def _toggle_all_buttons(self, value):
-        for button in self.findChildren(QPushButton):
+        for button in self.command_buttons:
             button.setEnabled(value)
             self._update_button_style(button)
 
@@ -125,3 +146,17 @@ class UserControlsWidget(QWidget):
         self.service_flag = flag
         self.button_service_flag_changed.emit(flag)
         # print(f"User controls service flag: {self.service_flag}")
+
+    def set_remap_mode_active(self, is_active: bool):
+        self.remap_mode_active = is_active
+
+    def refresh_key_labels(self):
+        for button, label in self.command_button_labels.items():
+            action = self.command_button_actions.get(button)
+            label.setText(self._format_command_label(action))
+
+    def _format_command_label(self, action, fallback_index=None):
+        key_text = self.commands.get_key_text(self.commands.get_toggle_key_for_action(action))
+        if key_text == "?" and fallback_index is not None:
+            return f"Command: {fallback_index}"
+        return f"Command: {key_text}"


### PR DESCRIPTION
To test, click on the `configure controls` button.
Then, press on any button and then overwrite its current keyboard assignment by pressing on a new keyboard key. After a new key is assigned, a `controls_config.json` should be written in the same location as the `main.py` or `Boccia.exe` file.

To test with the program compiled, run the following commands using the `boccia-gui` environment
```
cd Bbccia-gui
pyinstaller --onefile --windowed --noconsole --icon=brain.ico --name="Boccia.exe" --add-data "brain.png:."  main.py
```