### PR TITLE
Single keyboard multiplayer

### DIFF
--- a/boccia-gui/commands.py
+++ b/boccia-gui/commands.py
@@ -57,6 +57,25 @@ class Commands():
         "Drop \n(R)": "dd-70",
     }
 
+    MULTIPLAYER_TOGGLE_KEYS = {
+        "Player 1": {
+            "rotation_right": Qt.Key_A,
+            "drop": Qt.Key_Q,
+        },
+        "Player 2": {
+            "rotation_right": Qt.Key_S,
+            "drop": Qt.Key_W,
+        },
+        "Player 3": {
+            "rotation_right": Qt.Key_D,
+            "drop": Qt.Key_E,
+        },
+        "Player 4": {
+            "rotation_right": Qt.Key_F,
+            "drop": Qt.Key_R,
+        },
+    }
+
     # Min and max number of players for multiplayer mode
     MIN_MULTIPLAYERS = 2
     MAX_MULTIPLAYERS = 4
@@ -85,6 +104,11 @@ class Commands():
 
         self.hold_key_map = dict(self.DEFAULT_HOLD_KEYS)
         self.toggle_key_map = dict(self.DEFAULT_TOGGLE_KEYS)
+
+        self.multiplayer_key_map = {}
+        for player, actions in self.MULTIPLAYER_TOGGLE_KEYS.items():
+            for action, key in actions.items():
+                self.multiplayer_key_map[key] = (player, action)
 
     def set_user_controls_widget(self, user_controls_widget):
         self.user_controls_widget = user_controls_widget
@@ -140,6 +164,21 @@ class Commands():
         for action, mapped_key in self.toggle_key_map.items():
             if mapped_key == key:
                 return self.TOGGLE_ACTION_COMMANDS.get(action)
+            
+    def get_multiplayer_toggle_command_for_key(self, key):
+        result = self.multiplayer_key_map.get(key)
+        if not result:
+            return None
+        _, action = result
+        command = self.TOGGLE_ACTION_COMMANDS.get(action)
+        return command
+                
+    def get_player_for_toggle_key(self, key):
+        result = self.multiplayer_key_map.get(key)
+        if not result:
+            return None
+        player, _ = result
+        return player
 
     def get_hold_command_for_action(self, action):
         return self.HOLD_ACTION_COMMANDS.get(action)

--- a/boccia-gui/commands.py
+++ b/boccia-gui/commands.py
@@ -30,11 +30,12 @@ class Commands():
         "drop": "dd-70",
         }
 
+    # Use different keys than the Multiplayer Toggle Keys
     DEFAULT_HOLD_KEYS = {
-        "rotation_left": Qt.Key_Left,
-        "rotation_right": Qt.Key_Right,
-        "elevation_up": Qt.Key_Up,
-        "elevation_down": Qt.Key_Down,
+        "rotation_left": Qt.Key_J,
+        "rotation_right": Qt.Key_L,
+        "elevation_up": Qt.Key_I,
+        "elevation_down": Qt.Key_K,
         }
 
     DEFAULT_TOGGLE_KEYS = {
@@ -57,22 +58,24 @@ class Commands():
         "Drop \n(R)": "dd-70",
     }
 
+    # Based on available keyboard mapping in T2S iOS app
+    # Each player has a rotation right and drop toggle command
     MULTIPLAYER_TOGGLE_KEYS = {
         "Player 1": {
-            "rotation_right": Qt.Key_A,
-            "drop": Qt.Key_Q,
+            "rotation_right": Qt.Key_W,
+            "drop": Qt.Key_Space,
         },
         "Player 2": {
-            "rotation_right": Qt.Key_S,
-            "drop": Qt.Key_W,
+            "rotation_right": Qt.Key_A,
+            "drop": Qt.Key_Return,
         },
         "Player 3": {
-            "rotation_right": Qt.Key_D,
-            "drop": Qt.Key_E,
+            "rotation_right": Qt.Key_S,
+            "drop": Qt.Key_Up,
         },
         "Player 4": {
-            "rotation_right": Qt.Key_F,
-            "drop": Qt.Key_R,
+            "rotation_right": Qt.Key_D,
+            "drop": Qt.Key_Down,
         },
     }
 

--- a/boccia-gui/commands.py
+++ b/boccia-gui/commands.py
@@ -31,10 +31,10 @@ class Commands():
         }
 
     DEFAULT_HOLD_KEYS = {
-        "rotation_left": Qt.Key_A,
-        "rotation_right": Qt.Key_D,
-        "elevation_up": Qt.Key_W,
-        "elevation_down": Qt.Key_S,
+        "rotation_left": Qt.Key_Left,
+        "rotation_right": Qt.Key_Right,
+        "elevation_up": Qt.Key_Up,
+        "elevation_down": Qt.Key_Down,
         }
 
     DEFAULT_TOGGLE_KEYS = {

--- a/boccia-gui/controls_config.json
+++ b/boccia-gui/controls_config.json
@@ -1,9 +1,9 @@
 {
   "hold_keys": {
-    "rotation_left": 16777234,
-    "rotation_right": 16777236,
-    "elevation_up": 16777235,
-    "elevation_down": 16777237
+    "rotation_left": 74,
+    "rotation_right": 76,
+    "elevation_up": 73,
+    "elevation_down": 75
   },
   "toggle_keys": {
     "elevation_up": 49,

--- a/boccia-gui/controls_config.json
+++ b/boccia-gui/controls_config.json
@@ -1,0 +1,13 @@
+{
+  "hold_keys": {
+    "rotation_left": 16777234,
+    "rotation_right": 16777236,
+    "elevation_up": 16777235,
+    "elevation_down": 16777237
+  },
+  "toggle_keys": {
+    "elevation_up": 49,
+    "rotation_right": 50,
+    "drop": 51
+  }
+}

--- a/boccia-gui/key_press_handler.py
+++ b/boccia-gui/key_press_handler.py
@@ -48,6 +48,12 @@ class KeyPressHandler(QObject):
         if not event.isAutoRepeat():
             key = event.key()
 
+            command = self.commands.get_multiplayer_toggle_command_for_key(key)
+            if command:
+                player = self.commands.get_player_for_toggle_key(key)
+                self.toggle_key_pressed(player, command, key)
+                return
+
             command = self.commands.get_hold_command_for_key(key)
             if command:
                 self.hold_key_pressed(command, key)
@@ -56,6 +62,7 @@ class KeyPressHandler(QObject):
             command = self.commands.get_toggle_command_for_key(key)
             if command:
                 self.toggle_key_pressed("Player 1", command, key)
+                return
                 
             event.accept()
 
@@ -91,6 +98,7 @@ class KeyPressHandler(QObject):
                 return
             
             # Return if the player is not the current player
+            # this may be redundant since it already checks if the key pressed is the same as the toggled key
             if player != self.current_player:
                 return
             

--- a/boccia-gui/key_press_handler.py
+++ b/boccia-gui/key_press_handler.py
@@ -128,6 +128,7 @@ class KeyPressHandler(QObject):
 
             # Set the current player
             self.current_player = player
+            # print(self.current_player)
 
     def keyReleaseEvent(self, event):
         if not event.isAutoRepeat():

--- a/boccia-gui/main.py
+++ b/boccia-gui/main.py
@@ -4,7 +4,7 @@ from main_window import MainWindow
 
 def main():
     app = QApplication(sys.argv)
-    mainWindow = MainWindow(include_multiplayer_controls=True)
+    mainWindow = MainWindow(include_multiplayer_controls=False)
     mainWindow.show()
     sys.exit(app.exec_())
 

--- a/boccia-gui/main_window.py
+++ b/boccia-gui/main_window.py
@@ -2,6 +2,7 @@
 import os
 import sys
 from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (
     QWidget,
@@ -56,15 +57,17 @@ class MainWindow(QMainWindow):
         # Initialize user interface
         self.init_UI()
 
-        # Install event filter for keyboard events
+        # Initialize key press handler and connect it to commands and serial handler
         self.key_press_handler = KeyPressHandler(
-               self,
-               self.serial_handler, 
-               self.commands
-               )
-        
-        self.key_press_handler.installEventFilter(self)
-        self.installEventFilter(self.key_press_handler)
+            self,
+            self.serial_handler, 
+            self.commands
+            )
+
+        # Install the key press handler as a global event filter
+        app = QApplication.instance()
+        if app:
+            app.installEventFilter(self.key_press_handler)
         self.commands.set_key_press_handler(self.key_press_handler)
 
         # Set up event connections


### PR DESCRIPTION
This PR is to modify the app so that it can respond to more keyboard commands to support multiple players using iPads. Up to 4 players would be able to control the ramp one at a time, with each player's iPad connected via bluetooth to the keyboard of a Surface Pro.

- Added a set of keyboard toggle commands for 4 players. Each player has their own control for `rotation_right` and `drop`. The keys associated with each command are based on the keyboard mapping available in the iOS T2S app.
- Up to 4 iPads can be set up with two T2S commands mapped to one of the following sets of keys:
  - Player 1
    - Rotation right: **W**
    - Drop: **Space**
  - Player 2
    - Rotation right: **A**
    - Drop: **Enter**
  - Player 3
    - Rotation right: **S**
    - Drop: **Up Arrow**
  - Player 4
    - Rotation right: **D**
    - Drop: **Down Arrow**

- Changed `include_multiplayer_controls` to False when initializing `MainWindow` in `main.py`, because the UI to connect to devices is not necessary when using the iPads.
- Changed the four default Operator Hold Command keys from WASD to IJKL: I (up), L (right), K (down), and J (left) because there are limited keys available to map to in the iOS T2S app.